### PR TITLE
chore(all): update readme files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,32 @@
 # Powercoach Monorepo
 
-Monorepo Fastify API powered by TypeScript and pnpm, orchestrated with Turborepo for scalable builds and developer workflows.
+Turborepo-powered workspace that hosts the Powercoach backend, frontend manager, and shared tooling packages. Everything runs on Node 20, pnpm, and TypeScript with reproducible developer workflows.
 
 [![CI](https://github.com/ylojewski/powercoach/actions/workflows/ci.yml/badge.svg)](https://github.com/ylojewski/powercoach/actions/workflows/ci.yml) [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-**Topics:** monorepo · turborepo · fastify · typescript · pnpm
+**Topics:** monorepo · turborepo · fastify · react · typescript · pnpm
 
-This repository is managed with [Turborepo](https://turbo.build/). The root package declares the applications under `apps/` and
-shared packages under `packages/` as workspaces, enabling incremental builds and caching across the monorepo.
+This repository is managed with [Turborepo](https://turbo.build/). The root package declares the applications under `apps/` and shared packages under `packages/` as workspaces, enabling incremental builds and caching across the monorepo.
 
-## Projects
+## Workspace layout
 
-- [`@powercoach/api`](./apps/api) – Fastify HTTP API with health-check endpoint and opinionated architecture.
+### Applications
+
+- [`@powercoach/api`](./apps/api) – Fastify HTTP API that exposes health checks and future service endpoints.
+- [`@powercoach/manager`](./apps/manager) – React + Vite frontend that consumes the API (currently displaying backend health).
+
+### Shared packages
+
+- [`@powercoach/config`](./packages/config) – Centralized ESLint, Prettier, tsconfig, Vite, Vitest, Drizzle, lint-staged, commitlint, and tsup configuration.
+- [`@powercoach/db`](./packages/db) – Drizzle ORM schema, migrations, seeds, and typed Postgres client utilities.
+- [`@powercoach/util-env`](./packages/util-env) – Zod-powered environment loader with dotenv support and caching helpers.
+- [`@powercoach/util-test`](./packages/util-test) – Vitest utilities for spying on console output, stubbing environment variables, and validating Zod schemas.
 
 ## Getting started
 
 1. Install dependencies:
    ```sh
-   pnpm install
+   pnpm install --frozen-lockfile
    ```
 2. Start development tasks with Turbo:
    ```sh
@@ -29,5 +38,6 @@ Other helpful commands:
 - `pnpm build` – run the build pipeline for all packages.
 - `pnpm lint` – run lint tasks.
 - `pnpm test` – run tests.
+- `pnpm pre-commit` – run the full formatting, linting, typing, testing, and build chain expected before commits.
 
 Turbo caches the results of tasks to speed up subsequent runs. The cache directory `.turbo/` is ignored from version control.

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -1,6 +1,6 @@
 # @powercoach/api
 
-State-of-the-art Fastify API powered by Turborepo.
+Fastify HTTP API that powers Powercoach services. The server is written in TypeScript, bundled with tsup, and exposed through Turborepo tasks.
 
 ## Prerequisites
 
@@ -20,7 +20,7 @@ pnpm install
 - `pnpm test` – execute the Vitest end-to-end tests.
 - `pnpm lint` – lint the codebase with ESLint.
 - `pnpm format` – format the sources using Prettier.
-- `pnpm typecheck` – check types with Typescript .
+- `pnpm typecheck` – check types with TypeScript.
 
 ## Environment variables
 
@@ -35,12 +35,12 @@ Copy `.env.example` to `.env` and adjust the values if needed.
 
 ## API surface
 
-The API exposes a single health check endpoint:
+Initial endpoints focus on service readiness:
 
-- `GET /v1/health` – returns `{ ok: true, uptime: number }`
+- `GET /v1/health` – returns `{ ok: true, uptime: number }` via the health module in `src/modules/health`.
 
-To add a new module, duplicate the structure in `src/modules/health` and register the module in `src/app/buildApp.ts` with the desired route prefix.
+New modules can mirror the `src/modules/health` structure and be registered in `src/app/buildApp.ts` with their own route prefix. Shared utilities live under `src/app`.
 
 ## Testing strategy
 
-Tests use Fastify's `inject` API for fast, hermetic end-to-end coverage without opening network sockets. Each test spins up an in-memory Fastify instance
+Tests use Fastify's `inject` API for fast, hermetic end-to-end coverage without opening network sockets. Each test spins up an in-memory Fastify instance to validate handlers and plugins without side effects.

--- a/apps/manager/README.md
+++ b/apps/manager/README.md
@@ -1,0 +1,34 @@
+# @powercoach/manager
+
+React + Vite frontend for the Powercoach platform. The app currently displays API health status and is the entry point for future management tooling.
+
+## Prerequisites
+
+- Node.js 20+
+- pnpm 9+
+
+## Environment variables
+
+Copy `.env.example` to `.env` and set the backend origin:
+
+| Variable            | Description                         |
+| ------------------- | ----------------------------------- |
+| `VITE_API_BASE_URL` | Base URL for the API proxy in Vite. |
+
+During local development the Vite dev server proxies `/api` requests to `VITE_API_BASE_URL`, removing the `/api` prefix.
+
+## Scripts
+
+- `pnpm dev` – start the Vite dev server.
+- `pnpm build` – create a production build and prepare Vercel output.
+- `pnpm preview` – preview the production build locally.
+- `pnpm lint` – run ESLint.
+- `pnpm format` – check formatting with Prettier.
+- `pnpm typecheck` – run TypeScript type checks for source and tests.
+- `pnpm test` – execute Vitest with coverage.
+
+## Architecture notes
+
+- Entry point: `src/main.tsx` renders `<App />` into `index.html`.
+- API usage: `src/App.tsx` fetches `/api/v1/health` to render backend status.
+- Vite config: `vite.config.js` wires shared config from `@powercoach/config/vite` and applies the API proxy.

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -1,0 +1,34 @@
+# @powercoach/config
+
+Centralized configuration presets for the Powercoach monorepo. Each config is bundled with tsup and exposed through package exports for consistent linting, formatting, building, and testing across apps and packages.
+
+## What it provides
+
+- **ESLint** presets for TypeScript, React, and shared style rules.
+- **Prettier** configuration (including JSON sorting) and ignore rules.
+- **TypeScript** project templates for source and test builds.
+- **Tsup** build helper (`buildConfig`) for libraries and DTS generation.
+- **Vite** base config with React plugin support.
+- **Vitest** configuration for unit and coverage runs.
+- **Drizzle** CLI configuration for database packages.
+- **Commitlint** and **lint-staged** presets to enforce commit hygiene.
+
+## Usage
+
+Import the needed entry point from the package exports:
+
+```js
+// eslint.config.js
+import { config } from '@powercoach/config/eslint'
+export default config
+
+// tsup.config.js
+import { buildConfig } from '@powercoach/config/tsup'
+export default buildConfig(import.meta.url)
+
+// vite.config.js
+import { buildConfig } from '@powercoach/config/vite'
+export default buildConfig(import.meta.url)
+```
+
+See the `src` directory for the full list of available configs and helpers.

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -1,0 +1,36 @@
+# @powercoach/db
+
+Database toolkit for Powercoach built on Drizzle ORM and PostgreSQL. It ships schema definitions, migrations, seeds, and helpers for creating typed database clients.
+
+## Features
+
+- Zod-validated environment loading via `@powercoach/util-env` (`DATABASE_URL` required).
+- Drizzle schema definitions under `src/schema` with a metadata table.
+- Local development Docker Compose stack for PostgreSQL.
+- CLI scripts for generating and running migrations plus seeding.
+- Helper `createClient` to connect with `pg` and wrap the client with Drizzle.
+
+## Scripts
+
+- `pnpm db:up` – start the local PostgreSQL container.
+- `pnpm db:down` – stop and clean local containers and volumes.
+- `pnpm db:generate` – generate SQL migrations from the Drizzle schema.
+- `pnpm db:migrate` – apply migrations to the configured database.
+- `pnpm db:seed` – seed the database with sample data.
+- `pnpm db:reset` – full cycle: down, up, migrate, and seed.
+- `pnpm test` – run Vitest suite with coverage.
+- `pnpm build` – bundle the package with tsup.
+
+## Usage
+
+```ts
+import { createClient } from '@powercoach/db'
+
+async function example() {
+  const { db, pg } = await createClient()
+  const result = await db.select().from(/* tables here */)
+  await pg.end()
+}
+```
+
+Ensure `DATABASE_URL` is defined before using the package. Use the helper `resetCachedEnv` from `src/core/env` when tests mutate environment variables.

--- a/packages/util-env/README.md
+++ b/packages/util-env/README.md
@@ -1,0 +1,25 @@
+# @powercoach/util-env
+
+Environment loading utilities shared across the Powercoach monorepo. Built with Zod and dotenv for consistent validation and caching behavior between packages.
+
+## Core concepts
+
+- `envSchema` – base Zod schema requiring `NODE_ENV` and re-exported `NodeEnv` enum.
+- `createEnvLoader` – factory that builds cached loaders and exposes `resetCachedEnv` for tests.
+- `parseEnv` – helper to validate arbitrary `process.env` values and format Zod errors.
+
+## Usage
+
+```ts
+import { createEnvLoader, envSchema } from '@powercoach/util-env'
+
+const { loadEnv, resetCachedEnv } = createEnvLoader({
+  schema: envSchema,
+  format: (error) => `Invalid environment: ${error.message}`
+})
+
+const env = loadEnv()
+// env.NODE_ENV is strongly typed
+```
+
+Pair the base schema with package-specific extensions (see `@powercoach/db`) to validate additional variables while preserving the shared caching behavior.

--- a/packages/util-test/README.md
+++ b/packages/util-test/README.md
@@ -1,0 +1,21 @@
+# @powercoach/util-test
+
+Vitest helper utilities shared across Powercoach packages.
+
+## What it includes
+
+- `stubEnv` – stub multiple environment variables in one call using `vi.stubEnv`.
+- `expectZodParseToThrow` – assert that a Zod schema rejects invalid input and capture the resulting error.
+- `spyOnConsole` – silence and assert console methods by spying on specific functions.
+
+## Usage
+
+```ts
+import { expectZodParseToThrow, spyOnConsole, stubEnv } from '@powercoach/util-test'
+
+const error = expectZodParseToThrow(schema, { invalid: true })
+spyOnConsole(['error'])
+stubEnv({ NODE_ENV: 'test' })
+```
+
+Utilities are designed to be small building blocks that keep tests focused on behavior instead of setup noise.


### PR DESCRIPTION
## Summary
- expand root README to describe workspace layout and common workflows
- add package-specific READMEs covering api, manager, and shared libraries
- document scripts, environments, and usage patterns across apps and packages

## Testing
- `VITE_API_BASE_URL=http://localhost:8080 pnpm pre-commit`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931a54344488331a4be77be23e082eb)